### PR TITLE
Update jinja2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.7"
 lxml = "^4.6.1"
 marko = "^0.9.1"
 peggie = "^0.2.0"
-jinja2 = "^2.11.2"
+jinja2 = "^3.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "recipe_grid"
 version = "2.0.1"


### PR DESCRIPTION
The old version tries to import soft_unicode from markupsafe, which was removed in a minor version.

I also added pep-517 metadata so that i could install it without being a poet.